### PR TITLE
Fixes Issues with Nested Modules Cmdlets not Found

### DIFF
--- a/Modules/xSharePoint/xSharePoint.psd1
+++ b/Modules/xSharePoint/xSharePoint.psd1
@@ -70,7 +70,11 @@ NestedModules = @("modules\xSharePoint.DistributedCache\xSharePoint.DistributedC
 FunctionsToExport = '*'
 
 # Cmdlets to export from this module
-CmdletsToExport = '*'
+CmdletsToExport = @("Add-xSharePointDistributedCacheServer",
+                    "Remove-xSharePointDistributedCacheServer",
+                    "Get-xSharePointAuthenticatedPSSession",
+                    "Rename-xSharePointParamValue",
+                    "Remove-xSharePointNullParamValues")
 
 # Variables to export from this module
 VariablesToExport = '*'


### PR DESCRIPTION
Manually listed all cmdlets in Nested Modules in the psd1CmdletsToExport property